### PR TITLE
Set the default in the same pattern as result

### DIFF
--- a/thoth/license_solver/solver.py
+++ b/thoth/license_solver/solver.py
@@ -246,8 +246,11 @@ class Solver:
     def get_empty_dict() -> Dict[str, Any]:
         """Return empty dictionary for license."""
         return {
-            "license": "UNDETECTED",
-            "license_identifier": "UNDETECTED",
+            "license": {
+                "full_name": "UNDETECTED",
+                "identifier": "UNDETECTED",
+                "identifier_spdx": "UNDETECTED",
+            },
             "license_version": "UNDETECTED",
             "warning": True,
         }


### PR DESCRIPTION
Set the default in the same pattern as result
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/storages/issues/2703

## Description

- The default should be also in dict pattern. https://github.com/thoth-station/license-solver/blob/28c29dbf560c7165fd67419a3abfe3b53a1c6f1a/thoth/license_solver/package.py#L57
- The default should have similar pattern. https://github.com/thoth-station/license-solver/blob/28c29dbf560c7165fd67419a3abfe3b53a1c6f1a/thoth/license_solver/package.py#L122